### PR TITLE
Fix KOLIBRI_SCRIPT_DIR environment variable issue

### DIFF
--- a/windows/installer-source/KolibriSetupScript.iss
+++ b/windows/installer-source/KolibriSetupScript.iss
@@ -273,6 +273,13 @@ begin
       WizardForm.Close;
     end;
 
+    { Delete existing user and system KOLIBRI_SCRIPT_DIR envitoment variables }
+    RegDeleteValue(
+        HKLM,
+        'System\CurrentControlSet\Control\Session Manager\Environment',
+        'Kolibri_SCRIPT_DIR'
+    )
+    Exec('cmd.exe', '/c "reg delete HKCU\Environment /F /V KOLIBRI_SCRIPT_DIR"', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode)
     { Must set this environment variable so the systray executable knows where to find the installed kolibri.exe script}
     { Should by in the same directory as pip.exe, e.g. 'C:\Python27\Scripts' }
     RegWriteStringValue(


### PR DESCRIPTION
This fixes #18 

I tested that my old [PR](https://github.com/learningequality/kolibri-installer-windows/issues/16) doesn't fix the issue #18 if the machine was already infected by the issue. It only works in fresh installation.
 
@radinamatic to test this PR, Reproduced the issue #18 first and Install this [windows installer](https://drive.google.com/open?id=0B5Tyi-tRKOFMSHRqVFJ2QkxzTE0).





/cc @radinamatic @laurenlichtman @rtibbles @aronasorman 