### PR TITLE
Issue with selecting 'no' to installing Python

### DIFF
--- a/windows/installer-source/KolibriSetupScript.iss
+++ b/windows/installer-source/KolibriSetupScript.iss
@@ -204,6 +204,10 @@ begin
     end;
 end;
 
+{REF: http://stackoverflow.com/questions/4438506/exit-from-inno-setup-instalation-from-code}
+procedure ExitProcess(uExitCode: Integer);
+  external 'ExitProcess@kernel32.dll stdcall';
+
 procedure HandlePythonSetup;
 var
     installPythonErrorCode : Integer;
@@ -216,9 +220,14 @@ begin
         ShellExec('open', ExpandConstant('{tmp}')+'\python-exe.bat', '', '', SW_HIDE, ewWaitUntilTerminated, installPythonErrorCode);
     end
     else begin
-        MsgBox('Error' #13#13 'You must have Python 2.7.13+ installed to proceed! Installation will now exit.', mbError, MB_OK);
-        forceCancel := True;
-        WizardForm.Close;
+        if(MsgBox('Warning' #13#13 'Kolibri cannot run without installing Python.' #13#13 'Click Ok to go back and install Python, or Cancel to quit the Kolibri installer.', mbError, MB_OKCANCEL) = idCANCEL) then
+          begin
+            forceCancel := True;
+            ExitProcess(1);
+          end
+        else begin
+           HandlePythonSetup(); 
+        end
     end;
 end;
 


### PR DESCRIPTION
This fixes #30 

@radinamatic I can't use `exit` button as you suggested [here](https://github.com/learningequality/kolibri-installer-windows/issues/30#issuecomment-321302874)  the available buttons are `OK` and `Cancel`. You can grab the installer [here](https://drive.google.com/open?id=0B5Tyi-tRKOFMd0ctX0NPTktKWVE) for testing.