### PR TITLE
Add the python path to environment variables

### DIFF
--- a/windows/python-setup/python-exe.bat
+++ b/windows/python-setup/python-exe.bat
@@ -4,9 +4,27 @@ Set version=3.4.3
 Set python32Bit=python-%version%.msi
 Set python64Bit=python-%version%.amd64.msi
 Set pythonPath=%cd:~0,2%/Python34/Scripts
+Set envString=%Path%
+Set is_pythonPath=false
+
+rem check if pythonPath exist in environment variables
+:Check_Pyhon_Path_exist
+For /f "tokens=1* delims=;" %%i IN ("%envString%") DO (
+   If %pythonPath% == %%i (
+       Set is_pythonPath=true   
+   )
+   set envString=%%j
+   goto Check_Pyhon_Path_exist
+)
+
+If %is_pythonPath% == false (
+    Goto Add_Python_Path
+) Else (
+    Goto Check_Architecture
+)
 
 rem Add the pythonPath to environment variables.
-:Add_python_Path
+:Add_Python_Path
 Setx Path "%pythonPath%;%Path%"
 
 rem Execute python based on machine architecture.

--- a/windows/python-setup/python-exe.bat
+++ b/windows/python-setup/python-exe.bat
@@ -3,6 +3,11 @@
 Set version=3.4.3
 Set python32Bit=python-%version%.msi
 Set python64Bit=python-%version%.amd64.msi
+Set pythonPath=%cd:~0,2%/Python34/Scripts
+
+rem Add the pythonPath to environment variables.
+:Add_python_Path
+Setx Path "%pythonPath%;%Path%"
 
 rem Execute python based on machine architecture.
 :Check_Architecture

--- a/windows/python-setup/python-exe.bat
+++ b/windows/python-setup/python-exe.bat
@@ -8,13 +8,13 @@ Set envString=%Path%
 Set is_pythonPath=false
 
 rem check if pythonPath exist in environment variables
-:Check_Pyhon_Path_exist
+:Check_Python_Path_Exist
 For /f "tokens=1* delims=;" %%i IN ("%envString%") DO (
    If %pythonPath% == %%i (
-       Set is_pythonPath=true   
+       Set is_pythonPath=true
    )
-   set envString=%%j
-   goto Check_Pyhon_Path_exist
+   Set envString=%%j
+   Goto Check_Python_Path_Exist
 )
 
 If %is_pythonPath% == false (
@@ -32,10 +32,9 @@ rem Execute python based on machine architecture.
 If /i "%processor_architecture%"=="x86" (
     If NOT DEFINED PROCESSOR_ARCHITEW6432 (
         msiexec /i "%python32Bit%" /passive
-
     ) Else (
         msiexec /i "%python64Bit%" /passive
-    )           
+    )    
 ) Else (
         msiexec /i "%python64Bit%" /passive
 )


### PR DESCRIPTION
I enhance the python-exe.bat, to set the python path and add to the environment variables.

### Reference 
#102 