### PR TITLE
Fix Kolibri whl file temp path issue

### DIFF
--- a/src/installer-source/KolibriSetupScript.iss
+++ b/src/installer-source/KolibriSetupScript.iss
@@ -528,19 +528,22 @@ var
     PipCommand: string;
     PipPath: string;
     ErrorCode: integer;
+    TempFilePath: string;
+    SetEnvCmd: string;
 
 begin
     PipPath := GetPipPath();
     if PipPath = '' then
         exit;
-    PipCommand := 'install "' + ExpandConstant('{app}') + '\kolibri\kolibri-' + '{#TargetVersion}' + '-py2.py3-none-any' + '.whl"';
+    PipCommand := PipPath + ' install "' + ExpandConstant('{app}') + '\kolibri\kolibri-' + '{#TargetVersion}' + '-py2.py3-none-any' + '.whl"';
+    TempFilePath := GetEnv('HOMEDRIVE') + '\\temp'
+    SetEnvCmd := 'set TMP=' + TempFilePath + ' && ' + 'set TEMP=' + TempFilePath
     WizardForm.StatusLabel.WordWrap := true;
     WizardForm.StatusLabel.Height:=50 
     WizardForm.StatusLabel.Font.Style := [fsBold];
     WizardForm.StatusLabel.Caption := CustomMessage('SetupWizardMsg');
     WizardForm.ProgressGauge.Style := npbstMarquee;
-    
-    if not Exec(PipPath, PipCommand, '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
+    if not Exec('cmd.exe', '/S /C " ' + SetEnvCmd + ' && ' + PipCommand + '"', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
     begin
         FailedPipNotFound();
     end;


### PR DESCRIPTION
This fixes #143 

I set the temp folder into `HOMEDRIVE` to fix the long path issue during pip installation. This was commented by @rtibbles [here](https://github.com/learningequality/kolibri-installer-windows/issues/143#issuecomment-557821276)