### PR TITLE
Upgrade Python version to 3.6

### DIFF
--- a/src/inno-compiler/Default.isl
+++ b/src/inno-compiler/Default.isl
@@ -363,7 +363,7 @@ AddonHostProgramNotFound=%1 could not be located in the folder you selected.%n%n
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Bengali.islu
+++ b/src/inno-compiler/Languages/Bengali.islu
@@ -338,7 +338,7 @@ AddonHostProgramNotFound=আপনার নির্ধারিত ফোল�
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Bulgarian.isl
+++ b/src/inno-compiler/Languages/Bulgarian.isl
@@ -361,7 +361,7 @@ AddonHostProgramNotFound=%1 не бе намерена в избраната о�
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/French.isl
+++ b/src/inno-compiler/Languages/French.isl
@@ -382,7 +382,7 @@ AddonHostProgramNotFound=%1 n'a pas été trouvé dans le dossier que vous avez 
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/German.isl
+++ b/src/inno-compiler/Languages/German.isl
@@ -380,7 +380,7 @@ AddonHostProgramNotFound=%1 konnte im ausgewählten Ordner nicht gefunden werden
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Greek.isl
+++ b/src/inno-compiler/Languages/Greek.isl
@@ -368,7 +368,7 @@ AddonHostProgramNotFound=Το %1 δε βρέθηκε στο φάκελο που 
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Hindi.islu
+++ b/src/inno-compiler/Languages/Hindi.islu
@@ -338,7 +338,7 @@ AddonHostProgramNotFound=आपने चयन किया हुआफोल�
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Korean.isl
+++ b/src/inno-compiler/Languages/Korean.isl
@@ -369,7 +369,7 @@ AddonHostProgramNotFound=%1은(는) 선택한 폴더에 위치할 수 없습니다.%n%n그래도 계
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Marathi.islu
+++ b/src/inno-compiler/Languages/Marathi.islu
@@ -338,7 +338,7 @@ AddonHostProgramNotFound=तुम्ही निवडलेल्या फ�
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Nepali.isl
+++ b/src/inno-compiler/Languages/Nepali.isl
@@ -370,7 +370,7 @@ AddonHostProgramNotFound=तपाइले चयन गर्नु भएक�
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Portuguese.isl
+++ b/src/inno-compiler/Languages/Portuguese.isl
@@ -344,7 +344,7 @@ AddonHostProgramNotFound=Não foi possível localizar %1 na pasta seleccionada.%
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/inno-compiler/Languages/Spanish.isl
+++ b/src/inno-compiler/Languages/Spanish.isl
@@ -365,7 +365,7 @@ AddonHostProgramNotFound=¿%1 no podía ser ubicado en la carpeta selected.%n%nD
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=Hemos detectado una instalación existente de Kolibri; ¿quieres actualizar?
 UpgradeDelMsg=Instalación fresca borrará todos sus datos existentes; ¿Esto es lo que realmente quieres hacer?
-InstallPythonMsg=La versión 3.4+ de Python es necesaria para instalar Kolibri en Windows. ¿Desea instalar Python 3.4.3, antes de continuar con la instalación de Kolibri?
+InstallPythonMsg=La versión 3.6+ de Python es necesaria para instalar Kolibri en Windows. ¿Desea instalar Python 3.6.8, antes de continuar con la instalación de Kolibri?
 InstallPythonErrMsg=Advertencia - Kolibri necesita Python para funcionar. Haga clic en Aceptar para volver e instalar Python, o cancelar para salir del instalador de Kolibri
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Instalación de Kolibri ha fallado. Instalador de Kolibri encontró un errorinstallation process%n%n

--- a/src/inno-compiler/Languages/Vietnamese.isl
+++ b/src/inno-compiler/Languages/Vietnamese.isl
@@ -364,7 +364,7 @@ AddonHostProgramNotFound=%1 không thể được xác định trong thư mục 
 ; Kolibri Windows Installer custom messages
 UpgradeMsg=We have detected an existing Kolibri installation; would you like to upgrade?
 UpgradeDelMsg=Installing fresh will delete all of your existing data; is this what you really want to do?
-InstallPythonMsg=Python 3.4+ is required to install Kolibri on Windows; do you wish to first install Python 3.4.3, before continuing with the installation of Kolibri?
+InstallPythonMsg=Python 3.6+ is required to install Kolibri on Windows; do you wish to first install Python 3.6.8, before continuing with the installation of Kolibri?
 InstallPythonErrMsg=Kolibri cannot run without installing Python. Click Ok to go back and install Python, or Cancel to quit the Kolibri installer
 SetupKolibriErrMsg=Critical error. Dependencies have failed to install. Error Number:
 KolibriInstallFailed=Something went wrong during Kolibri setup.%nAdditional information can be found in the log file:

--- a/src/installer-source/KolibriSetupScript.iss
+++ b/src/installer-source/KolibriSetupScript.iss
@@ -45,7 +45,7 @@ Name: "bn"; MessagesFile: "compiler:Languages\Bengali.islu"
 
 [Files]
 Source: "..\kolibri*.whl"; DestDir: "{app}\kolibri"
-Source: "..\scripts\reset-env-vars.bat"; DestDir: "\Python34\Scripts\"
+Source: "..\scripts\reset-env-vars.bat"; DestDir: "\Python36\Scripts\"
 Source: "..\scripts\*.bat"; DestDir: "{app}\kolibri\scripts\"
 Source: "..\gui-packed\Kolibri.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\gui-packed\guitools.vbs"; DestDir: "{app}"; Flags: ignoreversion
@@ -445,7 +445,7 @@ end;
 
 { Used in GetPipPath below }
 const
-    DEFAULT_PIP_PATH = '\Python34\Scripts\pip.exe';
+    DEFAULT_PIP_PATH = '\Python36\Scripts\pip.exe';
 { Returns the path of pip.exe on the system. }
 { Tries several different locations before prompting user. }
 
@@ -461,8 +461,8 @@ begin
     if(MsgBox(CustomMessage('InstallPythonMsg'), mbConfirmation, MB_YESNO) = idYes) then
     begin
         try
-            ExtractTemporaryFile('python-3.4.3.amd64.msi');
-            ExtractTemporaryFile('python-3.4.3.msi');
+            ExtractTemporaryFile('python-3.6.8-amd64.exe');
+            ExtractTemporaryFile('python-3.6.8.exe');
             ExtractTemporaryFile('python-exe.bat');
             ExtractTemporaryFile('pip-6.0.8-py2.py3-none-any.whl');
             ShellExec('open', ExpandConstant('{tmp}')+'\python-exe.bat', '', '', SW_HIDE, ewWaitUntilTerminated, installPythonErrorCode);
@@ -588,7 +588,7 @@ begin
 
         Exec('cmd.exe', '/c "reg delete HKCU\Environment /F /V KOLIBRI_SCRIPT_DIR"', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode)
         { Must set this environment variable so the systray executable knows where to find the installed kolibri.exe script}
-        { Should by in the same directory as pip.exe, e.g. 'C:\Python33\Scripts' }
+        { Should by in the same directory as pip.exe, e.g. 'C:\Python36\Scripts' }
         RegWriteStringValue(
             HKLM,
             'System\CurrentControlSet\Control\Session Manager\Environment',
@@ -620,7 +620,7 @@ begin
    
     PythonPath := ExtractFileDir(GetEnv('KOLIBRI_SCRIPT_DIR')) + '\python.exe';
 
-    if ShellExec('open', PythonPath,'-c "import sys; (sys.version_info >= (3, 4, 0,) and sys.version_info < (3, 4, 7,) and sys.exit(0)) or sys.exit(1)"', '', SW_HIDE, ewWaitUntilTerminated, PythonVersionCodeCheck) then
+    if ShellExec('open', PythonPath,'-c "import sys; (sys.version_info >= (3, 6, 0,) and sys.version_info < (3, 6, 9,) and sys.exit(0)) or sys.exit(1)"', '', SW_HIDE, ewWaitUntilTerminated, PythonVersionCodeCheck) then
     begin
         if PythonVersionCodeCheck = 1 then
         begin

--- a/src/make.bat
+++ b/src/make.bat
@@ -56,23 +56,23 @@ FOR /f "tokens=1,2 delims=-" %%a in ("%WHL_FILE_NAME%") DO (
 :DOWNLOAD_PYTHON
 ECHO STEP 3/4. Downloading Python installers...
 :: TODO(cpauya): Find a way to get get this from a file like `PYTHON_VERSION.txt` instead of hard-coding here.
-SET VERSION=3.4.3
+SET VERSION=3.6.8
 SET PYTHON_URL=https://www.python.org/ftp/python/%VERSION%/python-%VERSION%
 SET PYTHON_DIR=%~dp0python-setup\python-%VERSION%
 
-SET PYTHON_MSI="%PYTHON_DIR%.msi"
-SET PYTHON_AMD64_MSI="%PYTHON_DIR%.amd64.msi"
+SET PYTHON_EXE="%PYTHON_DIR%.exe"
+SET PYTHON_AMD64_EXE="%PYTHON_DIR%.amd64.exe"
 
 :: MUST: Do not download the Python installers if they already exist!
-IF EXIST %PYTHON_MSI% (
-    ECHO ... found %PYTHON_MSI% so will NOT download it.
+IF EXIST %PYTHON_EXE% (
+    ECHO ... found %PYTHON_EXE% so will NOT download it.
 ) ELSE (
-    BITSADMIN /TRANSFER python-%VERSION%.msi /DOWNLOAD /PRIORITY NORMAL "%PYTHON_URL%.msi" "%PYTHON_MSI%"
+    BITSADMIN /TRANSFER python-%VERSION%.exe /DOWNLOAD /PRIORITY NORMAL "%PYTHON_URL%.exe" "%PYTHON_EXE%"
 )
-IF EXIST %PYTHON_AMD64_MSI% (
-    ECHO ... found %PYTHON_AMD64_MSI% so will NOT download it.
+IF EXIST %PYTHON_AMD64_EXE% (
+    ECHO ... found %PYTHON_AMD64_EXE% so will NOT download it.
 ) ELSE (
-    BITSADMIN /TRANSFER python-%VERSION%.amd64.msi /DOWNLOAD /PRIORITY NORMAL "%PYTHON_URL%.amd64.msi" "%PYTHON_AMD64_MSI%"
+    BITSADMIN /TRANSFER python-%VERSION%.amd64.exe /DOWNLOAD /PRIORITY NORMAL "%PYTHON_URL%.amd64.exe" "%PYTHON_AMD64_EXE%"
 )
 
 

--- a/src/python-setup/python-exe.bat
+++ b/src/python-setup/python-exe.bat
@@ -12,12 +12,12 @@ Set pipWhl=pip-6.0.8-py2.py3-none-any.whl
 rem Execute python based on machine architecture.
 If /i "%processor_architecture%"=="x86" (
   If NOT DEFINED PROCESSOR_ARCHITEW6432 (
-      start "" "%python32Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
+    	"%python32Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
   ) Else (
-      start "" "%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
+    	"%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
   )    
 ) Else (
-    start "" "%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
+   		"%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
 )
 
 rem reinstall pip

--- a/src/python-setup/python-exe.bat
+++ b/src/python-setup/python-exe.bat
@@ -1,26 +1,23 @@
 @echo off
 
-Set version=3.4.3
-Set python32Bit=python-%version%.msi
-Set python64Bit=python-%version%.amd64.msi
-Set pythonPath=%cd:~0,2%/Python34
+Set folderName=Python36
+Set version=3.6.8
+Set python32Bit=python-%version%.exe
+Set python64Bit=python-%version%-amd64.exe
+Set pythonPath=%cd:~0,2%/Python3.6.8
 Set pythonScriptPath="%pythonPath%/Scripts"
 Set pythonExe="%pythonPath%/python.exe"
 Set pipWhl=pip-6.0.8-py2.py3-none-any.whl
 
-rem Add the pythonPath to environment variables.
-echo %pythonScriptPath%
-Setx Path "%pythonScriptPath%;%Path%"
-
 rem Execute python based on machine architecture.
 If /i "%processor_architecture%"=="x86" (
   If NOT DEFINED PROCESSOR_ARCHITEW6432 (
-      msiexec /i "%python32Bit%" /passive
+      start "" "%python32Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
   ) Else (
-      msiexec /i "%python64Bit%" /passive
+      start "" "%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
   )    
 ) Else (
-    msiexec /i "%python64Bit%" /passive
+    start "" "%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
 )
 
 rem reinstall pip
@@ -29,4 +26,5 @@ If exist %pythonExe% (
     %pythonExe% %pipWhl%/pip install --upgrade --no-index %pipWhl%
   )
 )
+
 


### PR DESCRIPTION
We upgraded to Python 3.6 to fix these issues [#6813](https://github.com/learningequality/kolibri/issues/6813) #70 

Steps to test the H5P content:
* Install this [Kolibri Windows installer](https://drive.google.com/file/d/1pko_fjqAaey0YRFynfJii8AQ2Rh1-C_g/view?fbclid=IwAR1Yy_p2WQX0D1lVBzLEA7H58UAejg6nnXd_wffTg8xcLO1DXCCcIiXPv68) (Fyi, There is a bug where the installer ask twice to install Python first - I'm still fixing it.)
* Exit the Kolibri GUI to stop the kolibri server
* Open the command prompt and run this command `c:\Python36\Scripts\kolibri plugin enable kolibri.plugins.h5p_viewer` to enable H5P plugin
* Then start the Kolibri server
* Import the H5P samples contents using this token `piman-fapum`
* View H5P contents

cc @radinamatic @cpauya 
