### PR TITLE
Remove second call to getline

### DIFF
--- a/src/gui-source/Kolibri/Kolibri.cpp
+++ b/src/gui-source/Kolibri/Kolibri.cpp
@@ -74,7 +74,7 @@ char * getKolibriLinkAddress() {
 	if (file.is_open()) {
 		std::string line;
 		getline(file, line); // get the first line, do nothing
-		getline(file, line); // the second line should have the the port information
+		// the second line should have the the port information
 		if (isServerOnline("Kolibri session", joinChr("http://127.0.0.1:", line.c_str()))) {
 			httpLink = joinChr("http://127.0.0.1:", line.c_str());
 		}


### PR DESCRIPTION
Testing https://github.com/learningequality/kolibri/pull/8083, it seems like calling getline twice ends up _discarding_ the first two lines, so that when we read the line, we're actually getting the third line. So this just removes the second call.