### PR TITLE
Change options to install python

### DIFF
--- a/src/python-setup/python-exe.bat
+++ b/src/python-setup/python-exe.bat
@@ -12,12 +12,12 @@ Set pipWhl=pip-6.0.8-py2.py3-none-any.whl
 rem Execute python based on machine architecture.
 If /i "%processor_architecture%"=="x86" (
   If NOT DEFINED PROCESSOR_ARCHITEW6432 (
-    	"%python32Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
+	"%python32Bit%" /passive TargetDir="C:\%folderName%" InstallAllUsers=0 Include_doc=0 Include_pip=1 Include_test=0 Include_launcher=0 Include_tcltk=0
   ) Else (
-    	"%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
+	"%python64Bit%" /passive TargetDir="C:\%folderName%" InstallAllUsers=0 Include_doc=0 Include_pip=1 Include_test=0 Include_launcher=0 Include_tcltk=0
   )    
 ) Else (
-   		"%python64Bit%" /passive DefaultJustForMeTargetDir="C:\%folderName%"
+		"%python64Bit%" /passive TargetDir="C:\%folderName%" InstallAllUsers=0 Include_doc=0 Include_pip=1 Include_test=0 Include_launcher=0 Include_tcltk=0
 )
 
 rem reinstall pip


### PR DESCRIPTION
Changes the way to tell python where to be installed.
It also adds some parameters to install some unneeded files in the computer (documentation, tests, launcher and Tcl/Tk)

When a previous version of python has been installed, the option `DefaultJustForMeTargetDir` does not seem to work properly. It always installs python in %LocalAppData%\Programs\Python\PythonXY

Reference of the used parameters at https://docs.python.org/3/using/windows.html#installing-without-ui

Closes: #202 

Note: Only manual tests have been done, we'll need to have a kolibri installer built with these options to do a definitive check.