### PR TITLE
Update asset naming

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -16,11 +16,14 @@ on:
   workflow_call:
     inputs:
       whl-file-name:
-        required: true
+        required: false
+        type: string
+      whl-url:
+        required: false
         type: string
       ref:
         description: 'A ref for this workflow to check out its own repo'
-        required: true
+        required: false
         type: string
       release:
         description: 'Is this a release asset?'
@@ -44,6 +47,11 @@ jobs:
     outputs:
       exe-file-name: ${{ steps.get-exe-filename.outputs.exe-file-name }}
     steps:
+    - name: Validate whl reference inputs
+      if: ${{ (inputs.whl-file-name && inputs.whl-url) || (!inputs.whl-file-name && !inputs.whl-url) }}
+      run: |
+        echo "Must specify exactly one reference for the whl file to build the EXE with."
+        exit 1
     - uses: actions/checkout@v4
       if: ${{ !inputs.ref }}
     - uses: actions/checkout@v4
@@ -68,12 +76,12 @@ jobs:
       if: hashFiles('src\python-setup\python-3.8.10-amd64.exe') == ''
       run: curl -L -o src\python-setup\python-3.8.10-amd64.exe https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe
     - name: Download the whlfile from URL
-      if: ${{ github.event.inputs.whl-url }}
+      if: ${{ inputs.whl-url }}
       # Powershell recipe for downloading and using content disposition header:
       # https://hodgkins.io/download-file-with-powershell-without-renaming
       # Modified to remove query params
       run: |
-        $download = Invoke-WebRequest -Uri "${{ github.event.inputs.whl-url }}"
+        $download = Invoke-WebRequest -Uri "${{ inputs.whl-url }}"
         $content = [System.Net.Mime.ContentDisposition]::new($download.Headers["Content-Disposition"])
         $fileName = $content.FileName.split("?")[0]
         $file = [System.IO.FileStream]::new($fileName, [System.IO.FileMode]::Create)
@@ -108,12 +116,12 @@ jobs:
       id: get-exe-filename
       run: |
         import os
-        release = True if "${{ inputs.release == true || github.event.inputs.release == 'true' }}" == "true" else False
+        release = True if "${{ inputs.release == true }}" == "true" else False
         with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
           print("exe-file-name=kolibri-${{ steps.get-kolibri-version.outputs.kolibri-version }}-{}signed.exe".format("" if release else "un"), file=fh)
       shell: python
     - name: Codesign the exe
-      if: ${{ inputs.release == true || github.event.inputs.release == 'true' }}
+      if: ${{ inputs.release == true }}
       id: codesign
       run: |
         Set-Content -Path pfx.b64 -Value "${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}"

--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -118,7 +118,7 @@ jobs:
         import os
         release = True if "${{ inputs.release == true }}" == "true" else False
         with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-          print("exe-file-name=kolibri-${{ steps.get-kolibri-version.outputs.kolibri-version }}-{}signed.exe".format("" if release else "un"), file=fh)
+          print("exe-file-name=kolibri-${{ steps.get-kolibri-version.outputs.kolibri-version }}-windows-setup{}.exe".format("" if release else "-unsigned"), file=fh)
       shell: python
     - name: Codesign the exe
       if: ${{ inputs.release == true }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,0 +1,52 @@
+name: Build EXE for PRs
+
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  pre_job:
+    name: Path match check
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          github_token: ${{ github.token }}
+  latest_kolibri_release:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      whl-url: ${{ steps.get_latest_kolibri_release.outputs.result }}
+    steps:
+      - name: Get latest Kolibri release
+        id: get_latest_kolibri_release
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: 'learningequality',
+              repo: 'kolibri',
+              per_page: 1,
+              page: 1,
+            });
+
+            const latestRelease = releases[0];
+            const whlAsset = latestRelease.assets.find(asset => asset.name.endsWith('.whl'));
+            const whlUrl = whlAsset.browser_download_url;
+            return whlUrl;
+
+  build_apk:
+    name: Build Unsigned EXE
+    needs: [pre_job, latest_kolibri_release]
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/build_exe.yml
+    with:
+      whl-url: ${{ needs.latest_kolibri_release.outputs.whl-url }}


### PR DESCRIPTION
Adds github action to build assets for PRs.
Updates built name for asset to `kolibri-<version>-windows-setup.exe` if signed or `kolibri-<version>-windows-setup-unsigned.exe` if unsigned.