### PR TITLE
Allow up to Python 3.13 to be used.

### DIFF
--- a/src/installer-source/KolibriSetupScript.iss
+++ b/src/installer-source/KolibriSetupScript.iss
@@ -485,7 +485,7 @@ begin
   // Check if Python is installed
   PythonCoreKey := 'SOFTWARE\Python\PythonCore\';
   MinSupportedVersion:=6;
-  MaxSupportedVersion:=11;
+  MaxSupportedVersion:=13;
   PythonPath:= '';
   PythonExists := False;
 


### PR DESCRIPTION
## Summary
* Updates the max Python version from 3.11 to 3.13

## References
Needed for https://github.com/learningequality/kolibri/issues/12682