### PR TITLE
Ensure that the installer fails when the pip command fails, enable long paths

### DIFF
--- a/src/installer-source/KolibriSetupScript.iss
+++ b/src/installer-source/KolibriSetupScript.iss
@@ -629,6 +629,27 @@ begin
     else Log(Format('Error while adding the [%s] to PATH: [%s]', [param, Paths]));
 end;
 
+function EnableLongPathSupport(): Boolean;
+var
+  LongPathEnabled: Cardinal;
+begin
+  Result := True;
+
+  { Check if long path support is already enabled }
+  if RegQueryDWordValue(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\FileSystem', 'LongPathsEnabled', LongPathEnabled) then
+  begin
+    if LongPathEnabled = 1 then
+    begin
+      exit;
+    end;
+  end;
+
+  { Enable long path support by setting the registry value to 1 }
+  if not RegWriteDWordValue(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\FileSystem', 'LongPathsEnabled', 1) then
+    Result := False;
+end;
+
+
 procedure HandlePipSetup;
 var
     PipCommand: string;
@@ -639,6 +660,9 @@ var
     SetEnvCmd: string;
 
 begin
+    { Enable long path support before installing with pip }
+    EnableLongPathSupport();
+
     PipPath := GetPipPath();
     if PipPath = '' then
         exit;

--- a/src/installer-source/KolibriSetupScript.iss
+++ b/src/installer-source/KolibriSetupScript.iss
@@ -753,7 +753,7 @@ begin
             HKLM,
             'System\CurrentControlSet\Control\Session Manager\Environment',
             'KOLIBRI_INSTALLER_VERSION',
-            'v1.5.0'
+            'v1.6.6'
         );
 
 end;

--- a/src/installer-source/KolibriSetupScript.iss
+++ b/src/installer-source/KolibriSetupScript.iss
@@ -654,6 +654,12 @@ begin
     begin
         FailedPipNotFound();
     end;
+
+    { Check if pip command succeeded (ErrorCode = 0) }
+    if ErrorCode <> 0 then
+    begin
+        FailedPipNotFound();
+    end;
         { Delete existing user and system KOLIBRI_SCRIPT_DIR envitoment variables }
         RegDeleteValue(
             HKLM,


### PR DESCRIPTION
## Summary
* Check the exit code of the pip install command for the whl file
* Set the long path registry key to make sure that we can unpack the whl file properly

## References
Fixes issues seen on Windows 11 in https://github.com/learningequality/kolibri/pull/12746

## Reviewer guidance
We should check that the windows installer artifact from this PR still works
