### PR TITLE
pin to windows-2022 to avoid upgrading to latest

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -45,7 +45,7 @@ on:
 jobs:
   build_exe:
     name: Build EXE file
-    runs-on: windows-latest
+    runs-on: windows-2022
     outputs:
       exe-file-name: ${{ steps.get-exe-filename.outputs.exe-file-name }}
     steps:


### PR DESCRIPTION
## Summary
We will be deprecating this repository in the nearish future, so no point handling the upgrade, so just pin to windows-2022 instead.